### PR TITLE
Feat: Rate Limiting by API Key

### DIFF
--- a/Univast/settings/settings.py
+++ b/Univast/settings/settings.py
@@ -90,6 +90,12 @@ CSRF_TRUSTED_ORIGINS = [
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.coreapi.AutoSchema",
     "DEFAULT_AUTHENTICATION_CLASSES": (),
+    'DEFAULT_THROTTLE_CLASSES': [
+        "academia.throttling.APIKeyThrottling"
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        "rate": "50/hour"
+    }
 }
 
 # Password validation

--- a/academia/throttling.py
+++ b/academia/throttling.py
@@ -1,0 +1,13 @@
+# Django Imports
+from django.http import HttpRequest
+
+# Rest Framework Imports
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class APIKeyThrottling(SimpleRateThrottle):
+    scope = "rate"
+
+    def get_cache_key(self, request: HttpRequest, view):
+        api_key = request.headers.get("Authorization").split(" ")[-1]
+        return api_key

--- a/academia/views.py
+++ b/academia/views.py
@@ -51,6 +51,7 @@ def custom_bad_request_view(request, exception=None):
 class CountryListAPIView(generics.ListAPIView):
     serializer_class = CountrySerializer
     permission_classes = (HasAPIKey,)
+    throttle_scope = "rate"
     queryset = Country.objects.only("id", "name", "country_code")
 
     def get(self, request: Request) -> Response:
@@ -72,6 +73,7 @@ class CountryListAPIView(generics.ListAPIView):
 class SchoolListAPIView(generics.ListAPIView):
     serializer_class = SchoolSerializer
     permission_classes = (HasAPIKey,)
+    throttle_scope = "rate"
     queryset = School.objects.only(
         "id",
         "type",
@@ -133,6 +135,7 @@ class SchoolListAPIView(generics.ListAPIView):
 class SchoolFacultyListAPIView(generics.ListAPIView):
     serializer_class = FacultySerializer
     permission_classes = (HasAPIKey,)
+    throttle_scope = "rate"
     queryset = Faculty.objects.only("id", "name")
 
     def get(self, request: Request, school_code: str) -> Response:
@@ -163,6 +166,7 @@ class SchoolFacultyListAPIView(generics.ListAPIView):
 class DepartmentListAPIView(generics.ListAPIView):
     serializer_class = DepartmentSerializer
     permission_classes = (HasAPIKey,)
+    throttle_scope = "rate"
     queryset = Department.objects.prefetch_related("degree").only(
         "id", "name", "degree", "duration"
     )

--- a/throttle_test.py
+++ b/throttle_test.py
@@ -1,0 +1,14 @@
+import requests
+from decouple import config
+
+
+url = "http://127.0.0.1:8000/academia/schools/ng"
+api_key = config("API_KEY")
+headers = {
+    "accept": "application/json",
+    "authorization": f"Api-Key {api_key}",
+}
+
+for i in range(100):
+    r = requests.get(url, headers=headers)
+    print(f"Status Code {i+1}: {r.status_code}")


### PR DESCRIPTION
I did the following;

- created a custom throttling class to limit API requests by API key
- configured throttle class to rest_framework and added throttle_scope on all API views

Below is a demo of how the throttling feature works:

[238192212-b761b86d-bb53-4910-b050-1c697dcd4246.webm](https://github.com/faradayafrica/Univast/assets/55067204/03102951-2171-45bc-a97f-09b04fc14b32)


This PR resolves #8 

